### PR TITLE
Minor fixes to support hapi 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "raven": "0.7"
   },
   "peerDependencies": {
-    "hapi": "8"
+    "hapi": ">=8 <=9"
   },
   "devDependencies": {
     "boom": "~2.6.1",
     "chai": "1",
-    "hapi": "8",
+    "hapi": ">=8 <=9",
     "mocha": "1",
     "sinon": "1",
     "sinon-chai": "2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-raven",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A Hapi plugin for sending exceptions to Sentry through Raven",
   "main": "./src",
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -60,14 +60,14 @@ describe('hapi-raven', function () {
       captureError: capture
     });
     register();
-    server.inject('/', function () {
+    server.inject({url:'/', remoteAddress:'192.168.1.1'}, function () {
       expect(capture).to.have.been.calledWith(error, sinon.match.has('extra', {
         timestamp: sinon.match.number,
         id: sinon.match.string,
         method: 'get',
         path: '/',
         query: {},
-        remoteAddress: '',
+        remoteAddress: '192.168.1.1',
         userAgent: 'shot'
       }));
       raven.Client.restore();


### PR DESCRIPTION
I just updated the dependency and did a minor fix to make use of hapi's new remoteAddress argument in the tests. Things seem to be working so far.
