### PR TITLE
Allow to user Hapi 8-11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: node_js
 node_js:
 - '0.10'
+- '4'
+- '5'
+before_script:
+  - chmod +x ./run-tests.sh
+script:
+  - ./run-tests.sh
 deploy:
   provider: npm
   email: bvdrucker@gmail.com

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "chai": "1",
     "hapi": "8",
     "mocha": "1",
+    "semver": "^5.1.0",
     "sinon": "1",
     "sinon-chai": "2"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "raven": "0.7"
   },
   "peerDependencies": {
-    "hapi": "8"
+    "hapi": ">= 8 <= 11"
   },
   "devDependencies": {
     "boom": "~2.6.1",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -eu
+
+# Run the tests with the hapi version supported by current version of nodejs
+
+if [[ "$( node --version )" =~ v([0-9])\.[0-9]{1,2}\.[0-9]{1,2} ]]; then
+    node_version_major=${BASH_REMATCH[1]}
+else
+    echo "Can't determine version of nodejs"
+    exit 1
+fi
+
+case "$node_version_major" in
+
+0)
+    hapi_versions=( 8 9 )
+    ;;
+4)
+    hapi_versions=( 10 11 )
+    ;;
+5)
+    hapi_versions=( 11 )
+    ;;
+*)
+    echo "Unexpected nodejs version"
+    exit 1
+    ;;
+esac
+
+for version in "${hapi_versions[@]}"
+do
+    echo "Testing with hapi version $version"
+    npm install "hapi@$version"
+    npm test
+done

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,11 @@ var hapi   = require('hapi');
 var raven  = require('raven');
 var sinon  = require('sinon');
 var boom   = require('boom');
+var semver = require('semver');
+
+// Since we test the plugin with different versions of hapi, which behave a bit differently, we need
+// to determine the installed version
+var hapiMajorVersion = semver.major(require('hapi/package.json').version);
 
 /* globals describe:false, beforeEach:false, afterEach:false, it:false */
 
@@ -67,7 +72,7 @@ describe('hapi-raven', function () {
         method: 'get',
         path: '/',
         query: {},
-        remoteAddress: '',
+        remoteAddress: hapiMajorVersion === 8 ? '' : '127.0.0.1',
         userAgent: 'shot'
       }));
       raven.Client.restore();


### PR DESCRIPTION
I saw that two previous attempts ([4](https://github.com/bendrucker/hapi-raven/pull/4) and [5](https://github.com/bendrucker/hapi-raven/pull/5)) where rejected. Hope this one will succeed :)

1. The plugin is tested against all supported versions of hapi.
I had to make a small script to achieve that. This is the only way I know to do that. 
~~You can see it builds on my fork:
https://travis-ci.org/tepez/hapi-raven/builds/99422187~~
Check build to see it in action.

2. I made a tiny change to the specs. It is *necessary* because the `remoteAddress` in injected requests is differently in hapi 8 than in newer versions.

