### PR TITLE
Option to pass in tags to Sentry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@ exports.register = function (server, options, next) {
         query: request.query,
         remoteAddress: request.info.remoteAddress,
         userAgent: request.raw.req.headers['user-agent']
-      }
+      },
+      tags: options.tags
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -88,4 +88,19 @@ describe('hapi-raven', function () {
     });
   });
 
+  it('passes tags to Raven client', function (done) {
+    var capture = sinon.spy();
+    sinon.stub(raven, 'Client').returns({
+      captureError: capture
+    });
+    register({
+      tags: ['tag']
+    });
+    server.inject('/', function () {
+      expect(capture).to.have.been.calledWith(error, sinon.match.has('tags', ['tag']));
+      raven.Client.restore();
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
Hi @bendrucker,

First off thanks for this project, I had to do precisely this (report to Sentry from a Hapi based app), and I was glad to find this module on Github.

I had to pass in some tags to Sentry for every event, and added a tiny peace of code for that. Could you have a look and if you're happy with the change merge into the main repo?

Cheers,
Henrique Oliveira