### PR TITLE
captureError was renamed to captureException

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For convenience, hapi-raven [exposes](http://hapijs.com/api#pluginexposekey-valu
 ```js
 server.ext('onPreResponse', function (request, reply) {
   if (request.isBoom && request.response.statusCode === 404) {
-    server.plugins['hapi-raven'].client.captureError(request.response)
+    server.plugins['hapi-raven'].client.captureException(request.response)
   }
 })
 ```


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/blob/master/packages/raven-node/CHANGELOG.md#0110---552016

I only got the example working with "captureException" so i guess captureError was removed at some point